### PR TITLE
Fix PM2 process handling in deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
               exit 1
             fi
 
+            echo "Stopping old application..."
+            pm2 delete dublinstats-backend || true
             echo "Starting/restarting application..."
             pm2 restart server.js || pm2 start server.js --name dublinstats-backend
             pm2 save


### PR DESCRIPTION
Changes:
- Add explicit stopping of old PM2 process before starting new one
- Add logging for process stop step
- Maintain error handling with `|| true`

```yaml
echo "Stopping old application..."
pm2 delete dublinstats-backend || true